### PR TITLE
added undo / redo functionality

### DIFF
--- a/blackboard.js
+++ b/blackboard.js
@@ -608,6 +608,13 @@ function injectBlackboardComplete() {
 
   // Handle keyboard shortcuts for undo/redo
   const handleKeyboardShortcuts = (e) => {
+    // Handle Escape key to close the blackboard
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cleanupBlackboard();
+      return;
+    }
+
     // Handle Undo: Cmd+Z (Mac) or Ctrl+Z (Windows/Linux)
     if ((e.metaKey || e.ctrlKey) && e.key === "z" && !e.shiftKey) {
       e.preventDefault();


### PR DESCRIPTION
This pull request adds the undo / redo functionality to the blackboard for quick edits

Motivation: while using the extension, I found myself frequently go for a cmd+z rather than using the eraser tool to delete the last drawn stuff, but the browser would ignore the command and instead open the last closed tab

(Great extension btw)